### PR TITLE
Update dependencies - Compatible with ruby 2.5+

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6]
+        ruby-version: [2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tanker-identity (0.1.0)
-      rbnacl (~> 6.0.1)
+      rbnacl (~> 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
     ffi (1.12.2)
     json (2.3.0)
     rake (13.0.1)
-    rbnacl (6.0.1)
+    rbnacl (7.1.1)
       ffi
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,29 +13,28 @@ GEM
       url
     diff-lcs (1.3)
     docile (1.3.2)
-    ffi (1.10.0)
-    json (2.2.0)
-    rake (10.5.0)
+    ffi (1.12.2)
+    json (2.3.0)
+    rake (13.0.1)
     rbnacl (6.0.1)
       ffi
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    simplecov (0.17.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.1)
     url (0.3.2)
 
 PLATFORMS
@@ -44,10 +43,10 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   codecov
-  rake (~> 10.0)
+  rake (~> 13.0)
   rspec (~> 3.0)
   simplecov
   tanker-identity!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Identity generation in Ruby for the [Tanker SDK](https://tanker.io/docs/latest).
 
+## Requirements
+
+This gem requires Ruby v2.5 or greater (transitive requirement from [rbnacl](https://github.com/crypto-rb/rbnacl)).
+
+If still on an older version of Ruby, use `tanker-identity` with the [`603b35f8` commit ref](https://github.com/TankerHQ/identity-ruby/tree/603b35f8e1ca889c4862e8f9c1e54632a38b32b6).
+
 ## Installation
 
 This project depends on the [rbnacl](https://github.com/crypto-rb/rbnacl) gem, which requires the [libsodium](https://download.libsodium.org/doc/) cryptographic library.
@@ -11,12 +17,14 @@ Before going further, please follow [instructions to install libsodium](https://
 Then, add this line to your application's Gemfile:
 
 ```ruby
-gem 'tanker-identity', git: 'https://github.com/TankerHQ/identity-ruby' #, tag: 'vX.Y.Z'
+gem 'tanker-identity', git: 'https://github.com/TankerHQ/identity-ruby' #, ref: '<commit>'
 ```
 
 Finally, execute:
 
-    $ bundle
+```shell
+bundle
+```
 
 ## API
 

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rbnacl", "~> 6.0.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codecov"

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rbnacl", "~> 6.0.1"
+  spec.add_runtime_dependency "rbnacl", "~> 7.0"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
* Bump [rbnacl](https://github.com/crypto-rb/rbnacl) runtime dependency
* Requires Ruby 2.5 or greater