### PR TITLE
fix(require): make default require work with bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A secret identity.
 The server-side pseudo-code below demonstrates a typical flow to safely deliver identities to your users:
 
 ```ruby
-require 'tanker/identity'
+require 'tanker-identity'
 
 # 1. store these configurations in a safe place
 app_id = '<app-id>'

--- a/lib/tanker-identity.rb
+++ b/lib/tanker-identity.rb
@@ -1,3 +1,1 @@
 require 'tanker/identity'
-
-warn "DEPRECATION WARNING: Using `require 'tanker-identity'` is deprecated in favor of `require 'tanker/identity'`"


### PR DESCRIPTION
This is a partial revert of commit 7b1cd610.

We're accepting both:

- the recommended `require 'tanker/identity'` (see: [rubygems.org](https://guides.rubygems.org/name-your-gem/))
- the default `require 'tanker-identity'` that bundler uses

Fixes https://github.com/TankerHQ/identity-ruby/issues/13