### PR TITLE
chore(ci): fix tag collision on commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
       - name: Deploy
-        run: python -m poetry run python run-ci.py deploy --version "$(git describe --tags)"
+        run: python -m poetry run python run-ci.py deploy --version "${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
## What

`git describe --tags` failed to return le latest commit on this job https://github.com/TankerHQ/identity-ruby/runs/3220729902. We are expecting `v3.1.0` but got `v3.0.0`. `git describe --tags` returns the first tag in alphanumeric order.

## How

The env variable `GITHUB_REF` contains the tag used to trigger the action (i.e. `refs/tags/v3.1.0`). Using some variable substitution, we are able to isolate the tag from the `refs/tags/` prefix.