### PR TITLE
chore(ci): replace legacy coverage upload method

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,8 +23,8 @@ jobs:
         run: bundle exec bundle-audit check --update
       - name: Run tests
         run: bundle exec rspec
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,6 @@ GEM
     bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
-    codecov (0.5.2)
-      simplecov (>= 0.15, < 0.22)
     diff-lcs (1.4.4)
     docile (1.4.0)
     ffi (1.15.3)
@@ -23,6 +21,7 @@ GEM
       ffi
     reline (0.2.5)
       io-console (~> 0.5)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -42,6 +41,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     thor (1.1.0)
@@ -52,11 +54,11 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   bundler-audit (~> 0.7)
-  codecov
   rake (~> 13.0)
   rspec (~> 3.0)
   rubygems-tasks (~> 0.2.5)
   simplecov
+  simplecov-cobertura
   tanker-identity!
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 
 require 'bundler/setup'
 require 'tanker/identity'

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'rubygems-tasks', '~> 0.2.5'
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "codecov"
+  spec.add_development_dependency "simplecov-cobertura"
 end


### PR DESCRIPTION
It is now recommended to use the "new" uploader, either directly
or via the built-in GitHub Actions integration.

See:
* https://about.codecov.io/blog/introducing-codecovs-new-uploader/
* https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
* https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader