### PR TITLE
chore(e2ee-2629): add support for ruby 3.4 and drop support for ruby 3.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
       - name: Install and configure poetry
         run: python -m pip install poetry
       - name: Install python packages

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4']
     steps:
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
     steps:
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,44 +2,48 @@ PATH
   remote: .
   specs:
     tanker-identity (0.0.1)
+      base64 (~> 0.2.0)
       rbnacl (~> 7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bundler-audit (0.9.1)
+    base64 (0.2.0)
+    bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    date (3.4.1)
     diff-lcs (1.5.1)
-    docile (1.4.0)
-    ffi (1.16.3)
-    io-console (0.7.2)
-    irb (1.12.0)
-      rdoc
+    docile (1.4.1)
+    ffi (1.17.0)
+    io-console (0.8.0)
+    irb (1.14.3)
+      rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    psych (5.1.2)
+    psych (5.2.2)
+      date
       stringio
-    rake (13.1.0)
-    rbnacl (7.1.1)
-      ffi
-    rdoc (6.6.3.1)
+    rake (13.2.1)
+    rbnacl (7.1.2)
+      ffi (~> 1)
+    rdoc (6.10.0)
       psych (>= 4.0.0)
-    reline (0.5.0)
+    reline (0.6.0)
       io-console (~> 0.5)
-    rexml (3.2.6)
+    rexml (3.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     rubygems-tasks (0.2.6)
       irb (~> 1.0)
       rake (>= 10.0.0)
@@ -50,12 +54,13 @@ GEM
     simplecov-cobertura (2.1.0)
       rexml
       simplecov (~> 0.19)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.0)
-    thor (1.3.1)
+    stringio (3.1.2)
+    thor (1.3.2)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -63,10 +68,10 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rubygems-tasks (~> 0.2.5)
+  rubygems-tasks (~> 0.2.6)
   simplecov
   simplecov-cobertura
   tanker-identity!
 
 BUNDLED WITH
-   2.5.4
+   2.6.2

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ../..
   specs:
     tanker-identity (0.0.1)
+      base64 (~> 0.2.0)
       rbnacl (~> 7.0)
 
 GEM
@@ -10,15 +11,15 @@ GEM
     base64 (0.2.0)
     daemons (1.4.1)
     eventmachine (1.2.7)
-    ffi (1.16.3)
-    mustermann (3.0.0)
+    ffi (1.17.0)
+    mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.9)
+    rack (2.2.10)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
-    rbnacl (7.1.1)
-      ffi
+    rbnacl (7.1.2)
+      ffi (~> 1)
     ruby2_keywords (0.0.5)
     sinatra (3.2.0)
       mustermann (~> 3.0)
@@ -30,9 +31,10 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    tilt (2.3.0)
+    tilt (2.5.0)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -42,4 +44,4 @@ DEPENDENCIES
   thin (~> 1.8.2)
 
 BUNDLED WITH
-   2.5.4
+   2.6.2

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary     = %q{Tanker identity management library packaged as a gem}
   spec.description = %q{Building blocks to add Tanker identity management to your application server}
   spec.license     = "Apache-2.0"
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.2.0')
 
   spec.metadata["source_code_uri"] = "https://github.com/TankerHQ/identity-ruby"
   spec.metadata["changelog_uri"] = "https://docs.tanker.io/latest/release-notes/identity/ruby"

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -21,13 +21,14 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "base64", "~> 0.2.0"
   spec.add_runtime_dependency "rbnacl", "~> 7.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "bundler-audit", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency 'rubygems-tasks', '~> 0.2.5'
+  spec.add_development_dependency 'rubygems-tasks', '~> 0.2.6'
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-cobertura"
 end

--- a/tanker-identity.gemspec
+++ b/tanker-identity.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "base64", "~> 0.2.0"
-  spec.add_runtime_dependency "rbnacl", "~> 7.0"
+  spec.add_dependency "base64", "~> 0.2.0"
+  spec.add_dependency "rbnacl", "~> 7.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "bundler-audit", "~> 0.9"


### PR DESCRIPTION
* Ruby 3.4 was released on Christmas 🥳 🎄 (release notes: [3.4.0](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/) / [3.4.1](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/))
* Ruby 3.1 is EOL in less than 3 months (see: [Ruby](https://endoflife.date/ruby))